### PR TITLE
risc-v/bl602: update firmware to fix undefined symbols when linking

### DIFF
--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -52,11 +52,11 @@ CHIP_CSRCS += bl602_idle.c bl602_irq.c bl602_irq_dispatch.c
 CHIP_CSRCS += bl602_serial.c bl602_lowputc.c bl602_tim.c
 CHIP_CSRCS += bl602_start.c bl602_timerisr.c
 
-ifeq ($(CONFIG_I2C),y)                                                                               
+ifeq ($(CONFIG_I2C),y)
 CHIP_CSRCS += bl602_i2c.c
 endif
 
-ifeq ($(CONFIG_SPI),y)                                                                               
+ifeq ($(CONFIG_SPI),y)
 CHIP_CSRCS += bl602_spi.c
 endif
 
@@ -84,7 +84,7 @@ CHIP_CSRCS += bl602_glb.c bl602_gpio.c bl602_hbn.c bl602_systemreset.c
 ifeq ($(CONFIG_BL602_WIRELESS),y)
 WIRELESS_DRV_UNPACK  = bl_blob
 WIRELESS_DRV_VERSION = v1.6.19
-WIRELESS_DRV_ID      = main
+WIRELESS_DRV_ID      = dev_irq
 WIRELESS_DRV_ZIP     = $(WIRELESS_DRV_ID).zip
 WIRELESS_DRV_URL     = https://github.com/bouffalolab/bl_blob/archive
 


### PR DESCRIPTION
## Summary
update firmware to fix undefined up_irq_* symbols when linking

## Impact

## Testing

